### PR TITLE
Add material requirements for the training

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,14 @@ hands-on material.
 This training is for you if you need to deploy Larqe Language Models (LLMs) on
 your own infrastructure.
 
+For following along hands-on, you need * laptop or desktop with internet access.
+* a system set up so you can connect to an HPC system, an account on an HPC
+  system (e.g., VSC, CECI, ...), compute credits if that is required to run
+  jobs on the HPC system if you want to use an HPC system;
+* a Python environment that can run Jupyter Lab if you want to use your own
+  system (note that you would require a GPU for most of the examples to work);
+* access to Google Colaboratory if you prefer not to install software.
+
 
 ## Prerequisites
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
+title: "Deploying Large-Language Models locally"
 theme: jekyll-theme-slate


### PR DESCRIPTION
## Summary by Sourcery

Document material and access requirements for attending the LLM deployment training and set a site-wide documentation title.

Documentation:
- Add a list of hardware, HPC access, and software requirements for following the training hands-on.
- Set the documentation site title to 'Deploying Large-Language Models locally'.